### PR TITLE
Remove default private key that comes out of the box

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,8 @@ COPY bin/ /data/bin
 COPY src/ /data/src
 RUN touch /data/.env
 
+# Remove default ssl key
+RUN rm /etc/ssl/private/*
+
 ENTRYPOINT ["/data/bin/track-deployment"]
 CMD ["true"]


### PR DESCRIPTION
Related to 
https://trello.com/c/BolaByW5/564-remove-default-ssl-key-added-by-openssl-from-our-docker-images